### PR TITLE
Exclude expand.js from stryker

### DIFF
--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,5 +1,13 @@
 module.exports = (config) => {
 	config.set({
+		mutate: [
+			'{src,lib}/**/*.js?(x)',
+			'!{src,lib}/**/__tests__/**/*.js?(x)',
+			'!{src,lib}/**/?(*.)+(spec|test).js?(x)',
+			'!{src,lib}/**/*+(Spec|Test).js?(x)',
+			// Would prefer this as a comment in the file, but that's not possible
+			'!src/expand.js',
+		],
 		mutator:          'javascript',
 		packageManager:   'npm',
 		reporters:        ['clear-text', 'progress', 'dashboard'],
@@ -9,7 +17,7 @@ module.exports = (config) => {
 		thresholds:       {
 			high:  80,
 			low:   60,
-			break: 87.01,
+			break: 100,
 		},
 	});
 };


### PR DESCRIPTION
It's a copy from dotenv-expand, I don't really care about it's other code paths